### PR TITLE
testing: fix gracefully closing

### DIFF
--- a/backend/src/server.test.ts
+++ b/backend/src/server.test.ts
@@ -145,6 +145,8 @@ Deno.test({
             const chunkDelete = res as unknown as RPC.ChunkDeleteResult;
             assertEquals(chunkDelete.chunkId, "2");
             assertEquals(chunkDelete.seq, seq + 2);
+            // Wait 1100 ms for graceful shutdown.
+            await new Promise((resolve) => setTimeout(resolve, 1100));
         } finally {
             await stopServer();
         }

--- a/backend/src/testdata/test.syd
+++ b/backend/src/testdata/test.syd
@@ -1,1 +1,1 @@
-{"chunks":[{"id":"1","type":"text","content":"content"},{"id":"2","type":"text","content":""}],"tags":["A","B"],"version":1}
+{"chunks":[{"id":"1","type":"text","content":"content"}],"tags":["A","B"],"version":1}


### PR DESCRIPTION
일단 1100ms를 기다려서 종료함.
시그널 핸들러가 linux와 mac에서만 구현되어있기 때문에 이렇게 구현.
