### PR TITLE
fix: stop event bubling in FileTree

### DIFF
--- a/frontend/src/Component/FileTree.tsx
+++ b/frontend/src/Component/FileTree.tsx
@@ -63,8 +63,9 @@ const DirContent = forwardRef(function DirContent(
     const anchorRef = useRef<HTMLAnchorElement>(null);
     const [menuOpen, setMenuOpen] = useState(false);
 
-    const handleMenuClick = () => {
+    const handleMenuClick = (e: React.MouseEvent<HTMLElement>) => {
         setMenuOpen(true);
+        e.stopPropagation();
     };
     const handleMenuClose = () => {
         setMenuOpen(false);


### PR DESCRIPTION
FileTree에서 이벤트를 전파하고 있는 문제 해결.